### PR TITLE
Setup Motion Planner stubs

### DIFF
--- a/object_mover/object_mover/MotionPlanner.py
+++ b/object_mover/object_mover/MotionPlanner.py
@@ -1,0 +1,121 @@
+from rclpy.action import ActionClient
+from moveit_msgs.action import MoveGroup
+from geometry_msgs.msg import Pose
+from sensor_msgs.msg import JointState
+from moveit_msgs.msg import RobotState, Constraints, MotionPlanRequest
+from typing import Optional, List
+
+
+class MotionPlanner:
+    """
+    A class for planning motion paths using MoveIt.
+
+    This class provides methods for planning different types of motion paths:
+    - Joint configuration to joint configuration
+    - Pose to pose
+    - Cartesian paths
+    - Named configuration paths
+
+    Attributes
+    ----------
+    client : ActionClient
+        The action client used to communicate with the MoveIt action server.
+    """
+
+    def __init__(self):
+        """Initialize the MotionPlanner class."""
+        self.client = ActionClient(self, MoveGroup, 'move_action')
+
+        if not self.client.wait_for_server(timeout_sec=10):
+            raise RuntimeError('MoveGroup action server not ready')
+
+    async def execute_plan(self, plan):
+        """
+        Execute a previously planned motion.
+
+        :param plan: The planned motion to be executed.
+        :type plan: moveit_msgs.msg.MotionPlanRequest
+        :returns: True if execution is successful, False otherwise.
+        :rtype: bool
+        """
+        goal_handle = await self.client.send_goal_async(plan)
+        if not goal_handle.accepted:
+            return False
+
+        result = await goal_handle.get_result_async()
+        return result.result.error_code == 0
+
+    async def plan_joint_path(self, start_joints: Optional[List[float]], goal_joints: List[float]):
+        """
+        Plan a path from a starting joint configuration to a goal joint configuration.
+
+        :param start_joints: Starting joint angles. Uses current robot state if not provided.
+        :type start_joints: List[float], optional
+        :param goal_joints: Goal joint angles.
+        :type goal_joints: List[float]
+        :returns: The planned motion path request.
+        :rtype: moveit_msgs.msg.MotionPlanRequest
+        """
+        pass
+
+    async def plan_pose_to_pose(self, start_pose: Optional[Pose], goal_pose: Optional[Pose]):
+        """
+        Plan a path from a starting pose to a goal pose.
+
+        :param start_pose: Starting pose of the robot. Uses current robot state if not provided.
+        :type start_pose: geometry_msgs.msg.Pose, optional
+        :param goal_pose: Goal pose of the robot.
+        :type goal_pose: geometry_msgs.msg.Pose, optional
+        :returns: The planned motion path request.
+        :rtype: moveit_msgs.msg.MotionPlanRequest
+        """
+        pass
+
+    async def plan_cartesian_path(self, waypoints: List[Pose]):
+        """
+        Plan a Cartesian path from a sequence of waypoints.
+
+        :param waypoints: A list of poses that define the Cartesian path.
+        :type waypoints: List[geometry_msgs.msg.Pose]
+        :returns: The planned motion path request.
+        :rtype: moveit_msgs.msg.MotionPlanRequest
+        """
+        pass
+
+    async def plan_to_named_configuration(self, named_configuration: str):
+        """
+        Plan a path to a named configuration.
+
+        :param named_configuration: The name of the configuration to plan to.
+        :type named_configuration: str
+        :returns: The planned motion path request.
+        :rtype: moveit_msgs.msg.MotionPlanRequest
+        """
+        pass
+
+    def save_plan(self, plan):
+        """
+        Save a motion plan for future execution.
+
+        :param plan: The motion plan to save.
+        :type plan: moveit_msgs.msg.MotionPlanRequest
+        """
+        pass
+
+    def inspect_plan(self, plan):
+        """
+        Inspect a previously saved motion plan.
+
+        :param plan: The motion plan to inspect.
+        :type plan: moveit_msgs.msg.MotionPlanRequest
+        """
+        pass
+
+    async def get_current_robot_state(self) -> RobotState:
+        """
+        Get the current state of the robot.
+
+        :returns: The current state of the robot.
+        :rtype: moveit_msgs.msg.RobotState
+        """
+        pass


### PR DESCRIPTION
Functions Added:
```
execute_plan(plan)
plan_joint_path(start_joints, goal_joints)
plan_pose_to_pose(start_pose, goal_pose)
plan_cartesian_path(waypoints)
plan_to_named_configuration(named_configuration)
save_plan(plan)
inspect_plan(plan)
get_current_robot_state()
```

<ol><li><p><strong>Plan a path from any valid starting joint configuration to any valid goal joint configuration.</strong></p><ul><li><strong>Function</strong>: <code>plan_joint_path(start_joints: Optional[List[float]], goal_joints: List[float])</code></li><li><strong>Details</strong>:<ul><li>If <code>start_joints</code> is not provided, the method should use the <strong>current robot joint state</strong>.</li><li>Plans a path from the specified joint angles to the goal joint angles.</li></ul></li></ul></li><li><p><strong>Plan a path from a specified pose (position and orientation) from any starting configuration.</strong></p><ul><li><strong>Function</strong>: <code>plan_pose_to_pose(start_pose: Optional[Pose], goal_pose: Optional[Pose])</code></li><li><strong>Details</strong>:<ul><li>If <code>start_pose</code> is not provided, the method should use the <strong>current robot pose</strong>.</li><li>If only the <strong>goal position</strong> is specified (no orientation), the method should achieve the target position at <strong>any orientation</strong>.</li><li>If only the <strong>goal orientation</strong> is specified (no position), the method should achieve the target orientation at <strong>any position</strong>.</li></ul></li></ul></li><li><p><strong>Plan a Cartesian path from any valid starting pose to a goal pose.</strong></p><ul><li><strong>Function</strong>: <code>plan_cartesian_path(waypoints: List[Pose])</code></li><li><strong>Details</strong>:<ul><li>Uses a sequence of waypoints to plan a Cartesian path.</li><li>If the robot's current position is not provided as the first waypoint, the method should start from the <strong>current robot state</strong>.</li></ul></li></ul></li><li><p><strong>Plan a path from any valid starting pose to a named configuration.</strong></p><ul><li><strong>Function</strong>: <code>plan_to_named_configuration(named_configuration: str)</code></li><li><strong>Details</strong>:<ul><li>Plans a path to a predefined, named configuration (e.g., "home", "ready", etc.).</li><li>Uses the <strong>current robot state</strong> as the starting point if not specified.</li></ul></li></ul></li></ol><h3>Additional Functional Requirements</h3><ol start="5"><li><p><strong>Execute any planned path immediately after planning.</strong></p><ul><li><strong>Function</strong>: <code>execute_plan(plan)</code></li><li><strong>Details</strong>:<ul><li>After planning a path using any of the above methods, this method can be used to execute the planned motion immediately.</li></ul></li></ul></li><li><p><strong>Save any planned path for later execution.</strong></p><ul><li><strong>Function</strong>: <code>save_plan(plan)</code></li><li><strong>Details</strong>:<ul><li>Allows saving the <code>MotionPlanRequest</code> for future execution.</li><li>Useful for scenarios where the plan needs to be reused.</li></ul></li></ul></li><li><p><strong>Inspect any previously saved motion plan.</strong></p><ul><li><strong>Function</strong>: <code>inspect_plan(plan)</code></li><li><strong>Details</strong>:<ul><li>Enables viewing the details of a saved motion plan.</li><li>Useful for debugging and validation purposes.</li></ul></li></ul></li></ol>

